### PR TITLE
fix(swaps): prevent SSR crashes on production route

### DIFF
--- a/src/libs/appkit.ts
+++ b/src/libs/appkit.ts
@@ -14,10 +14,9 @@ import { walletAddress, walletChainId } from "../stores/user";
  * Public Reown/AppKit project id exposed to the client runtime.
  * Required because AppKit runs in browser context.
  */
-const projectId = import.meta.env.PUBLIC_REOWN_PROJECT_ID;
-if (!projectId) {
-  throw new Error("Missing PUBLIC_REOWN_PROJECT_ID environment variable");
-}
+const DEFAULT_REOWN_PROJECT_ID = "f168c45a3784d817b6572b95a96ecf80";
+const projectId =
+  import.meta.env.PUBLIC_REOWN_PROJECT_ID ?? DEFAULT_REOWN_PROJECT_ID;
 
 /**
  * Networks enabled across wallet connect + network switching flows.

--- a/src/pages/swaps.astro
+++ b/src/pages/swaps.astro
@@ -12,10 +12,10 @@ import NetworkSwitcherButton from "../components/NetworkSwitcherButton.svelte";
     class="md:min-h-[calc(100vh-3.5rem-3.5rem)] min-h-[calc(100vh-152px-3rem)] w-screen bg-neutral"
   >
     <div class="pt-4 pl-8">
-      <NetworkSwitcherButton client:load />
+      <NetworkSwitcherButton client:only="svelte" />
     </div>
     <div class="w-full pb-24 pt-12">
-      <SwapForm client:load />
+      <SwapForm client:only="svelte" />
     </div>
   </div>
   <Footer />


### PR DESCRIPTION
Avoid server-side failures on /swaps by ensuring swap UI islands are client-only and by falling back to a default public Reown project id when the env var is missing.

Made-with: Cursor