### PR TITLE
fix(api): support runtime env fallback for server routes

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -40,7 +40,13 @@ export function validateSupportedChainId(
 }
 
 export function validateRequiredEnv(envName: string): string {
-  const raw = (import.meta.env as Record<string, unknown>)[envName];
+  const rawFromImportMeta = (import.meta.env as Record<string, unknown>)[envName];
+  const rawFromProcess =
+    typeof process !== "undefined" ? process.env?.[envName] : undefined;
+  const raw =
+    typeof rawFromImportMeta === "string" && rawFromImportMeta.trim() !== ""
+      ? rawFromImportMeta
+      : rawFromProcess;
   if (typeof raw !== "string" || raw.trim() === "") {
     throw new Error(`${envName} not configured`);
   }


### PR DESCRIPTION
Read required environment variables from import.meta.env first and process.env as a fallback so Vercel runtime handlers can resolve API keys reliably.

Made-with: Cursor