### PR TITLE
fix(layout): render risk guard client-only

### DIFF
--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -22,6 +22,6 @@ const { title, description } = Astro.props;
   <body>
     <slot />
     <TransactionToast client:load />
-    <RiskAcknowledgmentGuard client:load />
+    <RiskAcknowledgmentGuard client:only="svelte" />
   </body>
 </html>


### PR DESCRIPTION
Avoid server-side rendering for the wallet risk guard so browser-only wallet logic does not break production requests.

Made-with: Cursor