### PR TITLE
feat(tokens): migrate selector token source to Blockscout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["apkt"]
+  "cSpell.words": ["apikey", "apkt"]
 }

--- a/src/locales/EN.json
+++ b/src/locales/EN.json
@@ -175,7 +175,7 @@
       "description": "Swap tokens with confidence.",
       "form": {
         "legendTokenIn": "You swap",
-        "legendTokenOut": "You receive",
+        "legendTokenOut": "You will receive",
         "swapAriaLabel": "Swap input and output tokens",
         "submit": "Swap",
         "submitting": "Swapping...",

--- a/src/pages/api/tokens/blockscout-tokens.ts
+++ b/src/pages/api/tokens/blockscout-tokens.ts
@@ -1,0 +1,324 @@
+import type { APIRoute } from "astro";
+import type { Address } from "viem";
+import type { TokenWithChainId } from "../../../sdk/types";
+import { buildLogoUrl } from "../../../sdk/utils";
+import {
+  getRedisClient,
+  parseTokenListCacheFromRedis,
+  persistTokenListToRedis,
+  validateApiKeyFromEnv,
+  validateRequiredEnv,
+  validateSupportedChainId,
+} from "../../../utils/api";
+import type {
+  BlockscoutTokenItem,
+  BlockscoutTokensListResponse,
+} from "../../../types/api";
+
+export const prerender = false;
+
+const DEFAULT_ITEMS_COUNT = 50;
+const MIN_ITEMS_COUNT = 1;
+const MAX_ITEMS_COUNT = 50;
+const CACHE_TTL_SEC = 12 * 60 * 60; // 12 hours
+const STALE_BACKGROUND_REFRESH_AFTER_MS = 10 * 60 * 60 * 1000; // 10 hours
+const MAX_STALE_SERVE_MS = CACHE_TTL_SEC * 1000; // 12 hours
+const REDIS_KEY_PREFIX = "blockscout:tokens:v1";
+
+/**
+ * Parses the optional `itemsCount` query param.
+ *
+ * @param raw - Raw query value.
+ * @returns Sanitized item count.
+ * @throws {Error} When value is not an integer in `[1, 50]`.
+ */
+function parseItemsCount(raw: string | null): number {
+  if (!raw || raw.trim() === "") return DEFAULT_ITEMS_COUNT;
+  const parsed = Number(raw);
+  if (
+    !Number.isInteger(parsed) ||
+    parsed < MIN_ITEMS_COUNT ||
+    parsed > MAX_ITEMS_COUNT
+  ) {
+    throw new Error(
+      `itemsCount must be an integer between ${MIN_ITEMS_COUNT} and ${MAX_ITEMS_COUNT}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Maps one Blockscout token row to the app `TokenWithChainId` shape.
+ *
+ * Only valid ERC-20 rows are accepted. Invalid/unsupported rows return `null`.
+ */
+function toTokenWithChainId(
+  chainId: number,
+  item: BlockscoutTokenItem,
+): TokenWithChainId | null {
+  if (item.type !== "ERC-20") return null;
+  if (!item.address_hash || !item.address_hash.startsWith("0x")) return null;
+  const decimals = Number(item.decimals);
+  if (!Number.isInteger(decimals) || decimals < 0) return null;
+
+  return {
+    chainId,
+    address: item.address_hash as Address,
+    decimals,
+    name: item.name?.trim() || "Unknown token",
+    symbol: item.symbol?.trim() || "UNKNOWN",
+    logo: buildLogoUrl(item.address_hash, chainId),
+  };
+}
+
+/**
+ * Fetches token rows from Blockscout and normalizes them to `TokenWithChainId[]`.
+ *
+ * @throws {Error} When Blockscout responds with non-2xx.
+ */
+async function fetchTokensFromBlockscout(
+  chainId: number,
+  itemsCount: number,
+  query: string | undefined,
+  apiKey: string,
+  configuredBaseUrl: string,
+): Promise<TokenWithChainId[]> {
+  const upstreamParams = new URLSearchParams();
+  upstreamParams.set("apikey", apiKey);
+  upstreamParams.set("type", "ERC-20");
+  upstreamParams.set("items_count", String(itemsCount));
+  if (query) upstreamParams.set("q", query);
+
+  const blockscoutBaseUrl = configuredBaseUrl.replace(
+    "{chain_id}",
+    chainId.toString(),
+  );
+  const upstreamUrl = `${blockscoutBaseUrl}/tokens/?${upstreamParams.toString()}`;
+
+  const upstreamResponse = await fetch(upstreamUrl);
+  if (!upstreamResponse.ok) {
+    const error = await upstreamResponse.json().catch(() => ({}));
+    console.error("Blockscout tokens upstream error:", error);
+    throw new Error("Failed to fetch Blockscout tokens");
+  }
+
+  const body = (await upstreamResponse.json()) as BlockscoutTokensListResponse;
+  const items = Array.isArray(body.items) ? body.items : [];
+  return items
+    .map((item) => toTokenWithChainId(chainId, item))
+    .filter((token): token is TokenWithChainId => token !== null);
+}
+
+/**
+ * Refreshes Redis cache asynchronously (fire-and-forget call site).
+ *
+ * Any error is logged and intentionally swallowed to avoid affecting responses.
+ */
+async function refreshRedisInBackground(
+  chainId: number,
+  itemsCount: number,
+  query: string | undefined,
+  apiKey: string,
+  configuredBaseUrl: string,
+  cacheKey: string,
+): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) return;
+
+  try {
+    const fresh = await fetchTokensFromBlockscout(
+      chainId,
+      itemsCount,
+      query,
+      apiKey,
+      configuredBaseUrl,
+    );
+    await persistTokenListToRedis(redis, cacheKey, fresh, CACHE_TTL_SEC);
+  } catch (error) {
+    console.error("Blockscout tokens background refresh:", error);
+  }
+}
+
+/**
+ * GET /api/tokens/blockscout-tokens
+ *
+ * Returns Blockscout token rows normalized to `TokenWithChainId` (ERC-20 only).
+ *
+ * Cache strategy mirrors `uniswap-tokens`:
+ * - fresh cache (<= 10h): return cached tokens
+ * - stale cache (10h-12h): return cached tokens and refresh in background
+ * - expired cache (>= 12h): block for fresh fetch (fallback to stale if available)
+ * - no cache: fetch from upstream and persist
+ *
+ * Query:
+ * - `chainId` (required): supported chain id.
+ * - `q` (optional): search query matched by Blockscout against token name/symbol.
+ * - `itemsCount` (optional): page size from 1 to 50. Defaults to 50.
+ */
+export const GET: APIRoute = async ({ request }) => {
+  let apiKey: string;
+  try {
+    apiKey = validateApiKeyFromEnv("BLOCKSCOUT_API_KEY");
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "BLOCKSCOUT_API_KEY not configured" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  let configuredBaseUrl: string;
+  try {
+    configuredBaseUrl = validateRequiredEnv("BLOCKSCOUT_API_URL");
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "BLOCKSCOUT_API_URL not configured" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const url = new URL(request.url);
+
+  let chainId: number;
+  let itemsCount: number;
+  try {
+    chainId = validateSupportedChainId(url.searchParams.get("chainId"));
+    itemsCount = parseItemsCount(url.searchParams.get("itemsCount"));
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Invalid query params",
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const query = url.searchParams.get("q")?.trim();
+  const normalizedQuery = (query ?? "").toLowerCase();
+
+  const redis = getRedisClient();
+  const cacheKey = `${REDIS_KEY_PREFIX}:${chainId}:${itemsCount}:${encodeURIComponent(normalizedQuery)}`;
+
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached) {
+        const entry = parseTokenListCacheFromRedis(cached);
+        if (entry) {
+          const { tokens, fetchedAt } = entry;
+          const ageMs = Date.now() - fetchedAt;
+
+          if (fetchedAt > 0 && ageMs <= STALE_BACKGROUND_REFRESH_AFTER_MS) {
+            return new Response(JSON.stringify({ tokens }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+
+          const mustAwaitFresh = ageMs >= MAX_STALE_SERVE_MS;
+
+          if (mustAwaitFresh) {
+            try {
+              const fresh = await fetchTokensFromBlockscout(
+                chainId,
+                itemsCount,
+                query,
+                apiKey,
+                configuredBaseUrl,
+              );
+              await persistTokenListToRedis(
+                redis,
+                cacheKey,
+                fresh,
+                CACHE_TTL_SEC,
+              );
+              return new Response(JSON.stringify({ tokens: fresh }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              });
+            } catch (error) {
+              console.error("Blockscout tokens sync refresh failed:", error);
+              if (tokens.length > 0) {
+                return new Response(JSON.stringify({ tokens }), {
+                  status: 200,
+                  headers: { "Content-Type": "application/json" },
+                });
+              }
+              throw error;
+            }
+          }
+
+          if (tokens.length > 0) {
+            void refreshRedisInBackground(
+              chainId,
+              itemsCount,
+              query,
+              apiKey,
+              configuredBaseUrl,
+              cacheKey,
+            );
+            return new Response(JSON.stringify({ tokens }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+
+          try {
+            const fresh = await fetchTokensFromBlockscout(
+              chainId,
+              itemsCount,
+              query,
+              apiKey,
+              configuredBaseUrl,
+            );
+            await persistTokenListToRedis(
+              redis,
+              cacheKey,
+              fresh,
+              CACHE_TTL_SEC,
+            );
+            return new Response(JSON.stringify({ tokens: fresh }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          } catch (error) {
+            console.error(
+              "Blockscout tokens sync refresh failed (empty cache):",
+              error,
+            );
+            throw error;
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Blockscout tokens Redis read:", error);
+    }
+  }
+
+  try {
+    const tokens = await fetchTokensFromBlockscout(
+      chainId,
+      itemsCount,
+      query,
+      apiKey,
+      configuredBaseUrl,
+    );
+
+    if (redis) {
+      try {
+        await persistTokenListToRedis(redis, cacheKey, tokens, CACHE_TTL_SEC);
+      } catch (error) {
+        console.error("Blockscout tokens Redis write:", error);
+      }
+    }
+
+    return new Response(JSON.stringify({ tokens }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Blockscout tokens:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch Blockscout tokens" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+};

--- a/src/pages/api/tokens/uniswap-tokens.ts
+++ b/src/pages/api/tokens/uniswap-tokens.ts
@@ -3,13 +3,16 @@ import type { Address } from "viem";
 import type Redis from "ioredis";
 import { SUPPORTED_CHAIN_IDS } from "../../../sdk/constants";
 import type {
-  UniswapTokenListCachedPayload,
   UniswapTokenListJson,
   UniswapTokenListToken,
 } from "../../../types/api";
 import type { TokenWithChainId } from "../../../sdk/types";
 import { buildLogoUrl } from "../../../sdk/utils";
-import { getRedisClient } from "../../../utils/api";
+import {
+  getRedisClient,
+  parseTokenListCacheFromRedis,
+  persistTokenListToRedis,
+} from "../../../utils/api";
 
 export const prerender = false;
 
@@ -19,6 +22,14 @@ const CACHE_TTL_SEC = 12 * 60 * 60; // 12 hours
 const STALE_BACKGROUND_REFRESH_AFTER_MS = 10 * 60 * 60 * 1000; // 10 hours
 const MAX_STALE_SERVE_MS = CACHE_TTL_SEC * 1000; // align with Redis TTL: beyond this, block until fresh
 
+/**
+ * Parses `address` query parameters into a normalized lowercase set.
+ *
+ * Supports repeated params and comma-separated values:
+ * `?address=0xabc&address=0xdef,0x123`.
+ *
+ * Returns `null` when no valid address filters are present.
+ */
 function parseAddressFilters(
   searchParams: URLSearchParams,
 ): Set<string> | null {
@@ -36,6 +47,7 @@ function parseAddressFilters(
   return new Set(normalized);
 }
 
+/** Maps one Uniswap token-list token into the app `TokenWithChainId` shape. */
 function toTokenWithChainId(t: UniswapTokenListToken): TokenWithChainId {
   return {
     chainId: t.chainId,
@@ -47,40 +59,11 @@ function toTokenWithChainId(t: UniswapTokenListToken): TokenWithChainId {
   };
 }
 
-function normalizeCachedTokenRow(row: unknown): TokenWithChainId | null {
-  if (!row || typeof row !== "object") return null;
-  const o = row as Record<string, unknown>;
-  if (
-    typeof o.chainId !== "number" ||
-    typeof o.address !== "string" ||
-    typeof o.decimals !== "number" ||
-    typeof o.name !== "string" ||
-    typeof o.symbol !== "string"
-  ) {
-    return null;
-  }
-  return {
-    chainId: o.chainId,
-    address: o.address as Address,
-    decimals: o.decimals,
-    name: o.name,
-    symbol: o.symbol,
-    logo: buildLogoUrl(o.address, o.chainId),
-  };
-}
-
-function parseTokenWithChainIdArray(
-  rows: unknown[],
-): TokenWithChainId[] | null {
-  const out: TokenWithChainId[] = [];
-  for (const row of rows) {
-    const t = normalizeCachedTokenRow(row);
-    if (!t) return null;
-    out.push(t);
-  }
-  return out;
-}
-
+/**
+ * Fetches Uniswap's default token list and filters it by supported chains.
+ *
+ * Throws when upstream responds with a non-2xx status.
+ */
 async function fetchSupportedTokensFromUniswap(): Promise<TokenWithChainId[]> {
   const res = await fetch(UNISWAP_TOKEN_LIST_URL);
   if (!res.ok) {
@@ -92,65 +75,32 @@ async function fetchSupportedTokensFromUniswap(): Promise<TokenWithChainId[]> {
     .map(toTokenWithChainId);
 }
 
-function parseRedisCache(raw: string): {
-  tokens: TokenWithChainId[];
-  fetchedAt: number;
-} | null {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) {
-      const tokens = parseTokenWithChainIdArray(parsed);
-      if (!tokens) return null;
-      return { tokens, fetchedAt: 0 };
-    }
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "tokens" in parsed &&
-      "fetchedAt" in parsed
-    ) {
-      const p = parsed as { tokens: unknown; fetchedAt: unknown };
-      if (!Array.isArray(p.tokens) || typeof p.fetchedAt !== "number") {
-        return null;
-      }
-      const tokens = parseTokenWithChainIdArray(p.tokens);
-      if (!tokens) return null;
-      return { tokens, fetchedAt: p.fetchedAt };
-    }
-  } catch {
-    /* ignore */
-  }
-  return null;
-}
-
-async function persistToRedis(
-  redis: Redis,
-  tokens: TokenWithChainId[],
-): Promise<void> {
-  const payload: UniswapTokenListCachedPayload = {
-    fetchedAt: Date.now(),
-    tokens,
-  };
-  await redis.setex(REDIS_KEY, CACHE_TTL_SEC, JSON.stringify(payload));
-}
-
 /** Updates Redis after fetch; errors are logged only (does not reject). */
 async function refreshRedisInBackground(redis: Redis): Promise<void> {
   try {
     const fresh = await fetchSupportedTokensFromUniswap();
-    await persistToRedis(redis, fresh);
+    await persistTokenListToRedis(redis, REDIS_KEY, fresh, CACHE_TTL_SEC);
   } catch (err) {
     console.error("UniswapTokens background refresh:", err);
   }
 }
 
+/**
+ * Loads supported tokens with stale-while-revalidate semantics.
+ *
+ * Behavior:
+ * - cache age <= 10h: return cache
+ * - 10h < cache age < 12h: return stale cache and refresh in background
+ * - cache age >= 12h or unknown age: block for fresh fetch (fallback to stale)
+ * - Redis unavailable or read error: fetch directly from upstream
+ */
 async function loadSupportedTokens(): Promise<TokenWithChainId[]> {
   const redis = getRedisClient();
   if (redis) {
     try {
       const cached = await redis.get(REDIS_KEY);
       if (cached) {
-        const entry = parseRedisCache(cached);
+        const entry = parseTokenListCacheFromRedis(cached);
         if (entry) {
           const { tokens, fetchedAt } = entry;
           const ageMs = Date.now() - fetchedAt;
@@ -159,12 +109,17 @@ async function loadSupportedTokens(): Promise<TokenWithChainId[]> {
             return tokens;
           }
 
-          const mustAwaitFresh = fetchedAt <= 0 || ageMs >= MAX_STALE_SERVE_MS;
+          const mustAwaitFresh = ageMs >= MAX_STALE_SERVE_MS;
 
           if (mustAwaitFresh) {
             try {
               const fresh = await fetchSupportedTokensFromUniswap();
-              await persistToRedis(redis, fresh);
+              await persistTokenListToRedis(
+                redis,
+                REDIS_KEY,
+                fresh,
+                CACHE_TTL_SEC,
+              );
               return fresh;
             } catch (err) {
               console.error("UniswapTokens sync refresh failed:", err);
@@ -180,7 +135,12 @@ async function loadSupportedTokens(): Promise<TokenWithChainId[]> {
 
           try {
             const fresh = await fetchSupportedTokensFromUniswap();
-            await persistToRedis(redis, fresh);
+            await persistTokenListToRedis(
+              redis,
+              REDIS_KEY,
+              fresh,
+              CACHE_TTL_SEC,
+            );
             return fresh;
           } catch (err) {
             console.error(
@@ -199,7 +159,7 @@ async function loadSupportedTokens(): Promise<TokenWithChainId[]> {
   const fresh = await fetchSupportedTokensFromUniswap();
   if (redis) {
     try {
-      await persistToRedis(redis, fresh);
+      await persistTokenListToRedis(redis, REDIS_KEY, fresh, CACHE_TTL_SEC);
     } catch (err) {
       console.error("UniswapTokens Redis write:", err);
     }

--- a/src/sdk/search/tokens.ts
+++ b/src/sdk/search/tokens.ts
@@ -1,6 +1,6 @@
 import type { Address } from "viem";
 import { retrieveTokenWithDetails } from "../token/retrieveTokenWithDetails";
-import { retrieveUniswapTokens } from "../tokens/retrieveUniswapTokens";
+import { retrieveBlockscoutTokens } from "../tokens/retrieveBlockscoutTokens";
 import type { Network, TokenWithChainId, TokenWithBalance } from "../types";
 import { retrieveTokensWithBalance } from "../user/retrieveTokensWithBalance";
 import { isValidAddress } from "../utils";
@@ -8,7 +8,7 @@ import { SUPPORTED_CHAIN_IDS } from "../constants";
 
 type SearchSelectorEmptyQueryMode = "balances" | "top10";
 
-const UNISWAP_PREVIEW_COUNT = 10;
+const BLOCKSCOUT_PREVIEW_COUNT = 20;
 
 export interface SearchSelectorTokensParams {
   walletAddress: Address;
@@ -18,15 +18,15 @@ export interface SearchSelectorTokensParams {
 }
 
 /**
- * Data for the token selector modal: combines wallet balances, Uniswap default list
+ * Data for the token selector modal: combines wallet balances, Blockscout token list
  * search, and single-token resolution by contract address. Rows are {@link TokenWithChainId} or {@link TokenWithBalance};
  *
- * - Empty query → see {@link SearchSelectorTokensParams.emptyQueryMode}: wallet balances (default) or Uniswap preview slice.
+ * - Empty query → see {@link SearchSelectorTokensParams.emptyQueryMode}: wallet balances (default) or Blockscout preview slice.
  * - Query that is a valid token address (incl. native sentinel) → one row from
  *   {@link retrieveTokenWithDetails} or empty if the API errors.
- * - Otherwise → Uniswap list for `chainId` filtered by query; rows with wallet balance
- *   come first; then wallet tokens that match the query but are not on that Uniswap
- *   slice; then remaining Uniswap matches.
+ * - Otherwise → Blockscout list for `chainId` filtered by query; rows with wallet balance
+ *   come first; then wallet tokens that match the query but are not on that Blockscout
+ *   slice; then remaining Blockscout matches.
  */
 export async function searchSelectorTokens(
   params: SearchSelectorTokensParams,
@@ -41,10 +41,13 @@ export async function searchSelectorTokens(
   if (q === "") {
     if (emptyQueryMode === "top10") {
       try {
-        const list = await retrieveUniswapTokens({ chainId });
-        return list.slice(0, UNISWAP_PREVIEW_COUNT);
+        const list = await retrieveBlockscoutTokens({
+          chainId,
+          itemsCount: BLOCKSCOUT_PREVIEW_COUNT,
+        });
+        return list.slice(0, BLOCKSCOUT_PREVIEW_COUNT);
       } catch {
-        throw new Error("Failed to load Uniswap token list");
+        throw new Error("Failed to load Blockscout token list");
       }
     }
 
@@ -87,30 +90,32 @@ export async function searchSelectorTokens(
   const addrKey = (a: string) => a.toLowerCase();
 
   try {
-    const [balanceTokens, uniswapList] = await Promise.all([
+    const [balanceTokens, blockscoutList] = await Promise.all([
       retrieveTokensWithBalance(walletAddress, { networks: [chainId] }),
-      retrieveUniswapTokens({ chainId }),
+      retrieveBlockscoutTokens({ chainId, q }),
     ]);
 
     const held = new Set(balanceTokens.map((t) => addrKey(t.address)));
-    const uniswapMatching = uniswapList.filter(matchesQuery);
-    const uniswapMatchKeys = new Set(
-      uniswapMatching.map((t) => addrKey(t.address)),
+    const blockscoutMatching = blockscoutList.filter(matchesQuery);
+    const blockscoutMatchKeys = new Set(
+      blockscoutMatching.map((t) => addrKey(t.address)),
     );
 
-    const uniswapHeld = uniswapMatching.filter((t) =>
+    const blockscoutHeld = blockscoutMatching.filter((t) =>
       held.has(addrKey(t.address)),
     );
-    const uniswapNotHeld = uniswapMatching.filter(
+    const blockscoutNotHeld = blockscoutMatching.filter(
       (t) => !held.has(addrKey(t.address)),
     );
 
     const balanceOnlyMatching = balanceTokens.filter(
-      (b) => matchesQuery(b) && !uniswapMatchKeys.has(addrKey(b.address)),
+      (b) => matchesQuery(b) && !blockscoutMatchKeys.has(addrKey(b.address)),
     );
 
-    return [...uniswapHeld, ...balanceOnlyMatching, ...uniswapNotHeld];
+    return [...blockscoutHeld, ...balanceOnlyMatching, ...blockscoutNotHeld];
   } catch {
-    throw new Error("Failed to retrieve tokens with balance or Uniswap list");
+    throw new Error(
+      "Failed to retrieve tokens with balance or Blockscout list",
+    );
   }
 }

--- a/src/sdk/tokens/retrieveBlockscoutTokens.ts
+++ b/src/sdk/tokens/retrieveBlockscoutTokens.ts
@@ -1,0 +1,62 @@
+import { SUPPORTED_CHAIN_IDS } from "../constants";
+import type { Network, TokenWithChainId } from "../types";
+
+const MIN_ITEMS_COUNT = 1;
+const MAX_ITEMS_COUNT = 50;
+
+export interface RetrieveBlockscoutTokensOptions {
+  chainId: Network["chainId"];
+  q?: string;
+  itemsCount?: number;
+}
+
+/**
+ * Fetches ERC-20 tokens from Blockscout via `GET /api/tokens/blockscout-tokens`.
+ *
+ * @param options - Required chain and optional search/pagination query.
+ * @returns Parsed `tokens` array from the API response.
+ * @throws {Error} When `chainId` is unsupported, `itemsCount` is invalid,
+ *   the response shape is malformed, or the request fails.
+ */
+export async function retrieveBlockscoutTokens(
+  options: RetrieveBlockscoutTokensOptions,
+): Promise<TokenWithChainId[]> {
+  if (!SUPPORTED_CHAIN_IDS.includes(options.chainId))
+    throw new Error("Unsupported chainId");
+
+  if (
+    options.itemsCount !== undefined &&
+    (!Number.isInteger(options.itemsCount) ||
+      options.itemsCount < MIN_ITEMS_COUNT ||
+      options.itemsCount > MAX_ITEMS_COUNT)
+  )
+    throw new Error(
+      `itemsCount must be an integer between ${MIN_ITEMS_COUNT} and ${MAX_ITEMS_COUNT}`,
+    );
+
+  const params = new URLSearchParams();
+  params.set("chainId", String(options.chainId));
+  if (options.q?.trim()) params.set("q", options.q.trim());
+  if (options.itemsCount !== undefined)
+    params.set("itemsCount", String(options.itemsCount));
+
+  const baseUrl = import.meta.env.PUBLIC_API_URL;
+  const url = `${baseUrl}/tokens/blockscout-tokens?${params.toString()}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      typeof (error as { error?: string }).error === "string"
+        ? (error as { error: string }).error
+        : "Failed to fetch Blockscout tokens",
+    );
+  }
+
+  const body = (await response.json()) as { tokens?: unknown };
+  if (!Array.isArray(body.tokens)) {
+    throw new Error("Invalid response shape from Blockscout tokens API");
+  }
+
+  return body.tokens as TokenWithChainId[];
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -84,6 +84,40 @@ export interface UniswapTokenListCachedPayload {
   tokens: TokenWithChainId[];
 }
 
+export interface BlockscoutTokenItem {
+  address_hash: string;
+  bridge_type: "omni" | "amb" | null;
+  circulating_market_cap: string | null;
+  decimals: string | null;
+  exchange_rate: string | null;
+  foreign_address: string | null;
+  holders_count: string | null;
+  icon_url: string | null;
+  name: string | null;
+  origin_chain_id: string | null;
+  reputation: "ok" | "scam" | null;
+  symbol: string | null;
+  total_supply: string | null;
+  type: "ERC-20" | "ERC-721" | "ERC-1155" | "ERC-404" | "ERC-7984" | null;
+  volume_24h: string | null;
+}
+
+export interface BlockscoutTokensNextPageParams {
+  contract_address_hash?: string;
+  fiat_value?: string;
+  holders_count?: number | string;
+  is_name_null?: boolean;
+  market_cap?: string;
+  name?: string;
+  items_count?: number;
+  [key: string]: unknown;
+}
+
+export interface BlockscoutTokensListResponse {
+  items: BlockscoutTokenItem[];
+  next_page_params: BlockscoutTokensNextPageParams | null;
+}
+
 export interface ZeroExFeeEntry {
   amount: string;
   token: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -7,7 +7,7 @@ import {
 } from "../sdk/constants";
 import { isValidAddress } from "../sdk/utils";
 import { amountToUsdScaled } from "../sdk/utils";
-import type { Network, SwapFee } from "../sdk/types";
+import type { Network, SwapFee, TokenWithChainId } from "../sdk/types";
 import { retrieveTokenWithDetails } from "../sdk/token/retrieveTokenWithDetails";
 import type { ResolveTokenDetails, ZeroExFeeEntry } from "../types/api";
 
@@ -177,4 +177,69 @@ export function getRedisClient(): Redis | null {
   }
 
   return redisClient;
+}
+
+/**
+ * Persists a token-list payload in Redis with a fetch timestamp.
+ *
+ * The stored JSON shape is `{ fetchedAt, tokens }`, which is reused by token-list
+ * API endpoints for cache reads and stale-age checks.
+ */
+export async function persistTokenListToRedis(
+  redis: Redis,
+  cacheKey: string,
+  tokens: TokenWithChainId[],
+  ttlSec: number,
+): Promise<void> {
+  await redis.setex(
+    cacheKey,
+    ttlSec,
+    JSON.stringify({
+      fetchedAt: Date.now(),
+      tokens,
+    }),
+  );
+}
+
+/**
+ * Parses token-list cache payload from Redis.
+ *
+ * Expected JSON shape: `{ fetchedAt: number, tokens: TokenWithChainId[] }`.
+ * Returns `null` when payload is malformed.
+ */
+export function parseTokenListCacheFromRedis(raw: string): {
+  tokens: TokenWithChainId[];
+  fetchedAt: number;
+} | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+
+    const payload = parsed as { fetchedAt?: unknown; tokens?: unknown };
+    if (!Array.isArray(payload.tokens)) return null;
+    if (
+      typeof payload.fetchedAt !== "number" ||
+      !Number.isFinite(payload.fetchedAt) ||
+      payload.fetchedAt <= 0
+    ) {
+      return null;
+    }
+
+    const tokens = payload.tokens.filter(
+      (row): row is TokenWithChainId =>
+        !!row &&
+        typeof row === "object" &&
+        typeof (row as { chainId?: unknown }).chainId === "number" &&
+        typeof (row as { address?: unknown }).address === "string" &&
+        typeof (row as { decimals?: unknown }).decimals === "number" &&
+        typeof (row as { name?: unknown }).name === "string" &&
+        typeof (row as { symbol?: unknown }).symbol === "string" &&
+        typeof (row as { logo?: unknown }).logo === "string",
+    );
+    if (tokens.length !== payload.tokens.length) return null;
+
+    return { tokens, fetchedAt: payload.fetchedAt };
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Switch token discovery from Uniswap lists to Blockscout-backed APIs with shared Redis cache parsing/persistence helpers so search and previews stay fresher and more resilient across chains.