### PR TITLE
fix(ui): harden swap detail wrapping on small screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ but I'm actively working on posting engaging content very soon. Stay tuned for u
 | PRODUCTION | https://venturarodriguez.xyz        | main    | Production |
 | PREVIEW    | https://venturarodriguez.vercel.app | staging | Preview    |
 | LOCALHOST  | http://localhost:3000               | NA      | NA         |
+
+<!-- Mejorar la visualización del order route -->
+<!-- Meter sistema de caché en el sdk -->
+<!-- mejorar la doc -->
+<!-- separar el sdk -->
+<!-- Meter una sección de dar feedback -->
+<!-- mejor manejo de errores -->

--- a/src/components/SwapDetails.svelte
+++ b/src/components/SwapDetails.svelte
@@ -125,23 +125,27 @@
       ></span>
     </div>
   {:else}
-    <div class="flex items-start justify-between gap-2 max-xs:flex-col">
+    <div class="flex min-w-0 items-start justify-between gap-2 max-xs:flex-col">
       <span>{locales.rateLabel}</span>
-      <span class="text-right wrap-break-word max-xs:text-left">
+      <span
+        class="min-w-0 text-right wrap-break-word max-xs:max-w-full max-xs:text-left"
+      >
         1 {tokenInSymbol} =
         {details.rate !== null
           ? ` ${formatRate(details.rate)} ${tokenOutSymbol}`
           : ` ${locales.rateFallback}`}
       </span>
     </div>
-    <div class="flex items-start justify-between gap-2 max-xs:flex-col">
+    <div class="flex min-w-0 items-start justify-between gap-2 max-xs:flex-col">
       <span
-        class="tooltip tooltip-right cursor-help max-xs:tooltip-bottom"
+        class="tooltip tooltip-mobile-safe tooltip-right cursor-help max-xs:tooltip-bottom"
         data-tip={locales.minimumReceived.tooltip}
       >
         {locales.minimumReceived.label}
       </span>
-      <span class="text-right wrap-break-word max-xs:text-left">
+      <span
+        class="min-w-0 text-right wrap-break-word max-xs:max-w-full max-xs:text-left"
+      >
         {details.minReceivedToken}
         {#if details.minReceivedToken !== "-"}
           {` ${tokenOutSymbol}`}
@@ -149,36 +153,39 @@
         {` (${details.minReceivedUsd})`}
       </span>
     </div>
-    <div class="flex items-start justify-between gap-2 max-xs:flex-col">
+    <div class="flex min-w-0 items-start justify-between gap-2 max-xs:flex-col">
       <span
-        class="tooltip tooltip-right cursor-help underline max-xs:tooltip-bottom"
+        class="tooltip tooltip-mobile-safe tooltip-right cursor-help underline max-xs:tooltip-bottom"
         data-tip={locales.swapPriceImpact.tooltip}
       >
         {locales.swapPriceImpact.label}
       </span>
-      <span class="text-right wrap-break-word max-xs:text-left"
+      <span
+        class="min-w-0 text-right wrap-break-word max-xs:max-w-full max-xs:text-left"
         >{details.swapPriceImpactPercent} ({details.swapPriceImpactUsd})</span
       >
     </div>
-    <div class="flex items-start justify-between gap-2 max-xs:flex-col">
+    <div class="flex min-w-0 items-start justify-between gap-2 max-xs:flex-col">
       <span
-        class="tooltip tooltip-right cursor-help underline max-xs:tooltip-bottom"
+        class="tooltip tooltip-mobile-safe tooltip-right cursor-help underline max-xs:tooltip-bottom"
         data-tip={locales.feePriceImpact.tooltip}
       >
         {locales.feePriceImpact.label}
       </span>
-      <span class="text-right wrap-break-word max-xs:text-left"
+      <span
+        class="min-w-0 text-right wrap-break-word max-xs:max-w-full max-xs:text-left"
         >{details.feePriceImpactPercent} ({details.feePriceImpactUsd})</span
       >
     </div>
-    <div class="flex items-start justify-between gap-2 max-xs:flex-col">
+    <div class="flex min-w-0 items-start justify-between gap-2 max-xs:flex-col">
       <span
-        class="tooltip tooltip-right cursor-help underline max-xs:tooltip-bottom"
+        class="tooltip tooltip-mobile-safe tooltip-right cursor-help underline max-xs:tooltip-bottom"
         data-tip={locales.priceImpact.tooltip}
       >
         {locales.priceImpact.label}
       </span>
-      <span class="text-right wrap-break-word max-xs:text-left"
+      <span
+        class="min-w-0 text-right wrap-break-word max-xs:max-w-full max-xs:text-left"
         >{details.priceImpactPercent} ({details.priceImpactUsd})</span
       >
     </div>


### PR DESCRIPTION
Prevent overflow in swap detail rows by tightening mobile-safe width and tooltip classes, and keep the README backlog notes tracked for follow-up work.

Made-with: Cursor